### PR TITLE
docs: clarify team in charge of this repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* Optravis-LLC/flow-analyzer

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* Optravis-LLC/flow-analyzer
+* @Optravis-LLC/flow-analyzer


### PR DESCRIPTION
As we start to have many repositories all around the Optravis organization, I would like to clarify who's owning which repo by adding a `CODEOWNERS` file in each of them.

It will serve as documentation and GitHub will automatically assign reviewers to pull requests.